### PR TITLE
Allow a user to have more than one OcppTag (backport steve#1777)

### DIFF
--- a/src/main/java/de/rwth/idsg/steve/repository/OcppTagRepository.java
+++ b/src/main/java/de/rwth/idsg/steve/repository/OcppTagRepository.java
@@ -40,6 +40,7 @@ public interface OcppTagRepository {
     OcppTagActivityRecord getRecord(int ocppTagPk);
 
     List<String> getIdTags();
+    List<String> getIdTagsWithoutUser();
     List<String> getActiveIdTags();
 
     List<String> getParentIdTags();

--- a/src/main/java/de/rwth/idsg/steve/repository/dto/User.java
+++ b/src/main/java/de/rwth/idsg/steve/repository/dto/User.java
@@ -22,8 +22,9 @@ import jooq.steve.db.tables.records.AddressRecord;
 import jooq.steve.db.tables.records.UserRecord;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 
-import java.util.Optional;
+import java.util.List;
 
 /**
  * @author Sevket Goekay <sevketgokay@gmail.com>
@@ -34,8 +35,9 @@ public class User {
     @Getter
     @Builder
     public static final class Overview {
-        private final Integer userPk, ocppTagPk;
-        private final String ocppIdTag, name, phone, email;
+        private final Integer userPk;
+        private final String name, phone, email;
+        private final List<OcppTagEntry> ocppTagEntries;
     }
 
     @Getter
@@ -43,6 +45,14 @@ public class User {
     public static final class Details {
         private final UserRecord userRecord;
         private final AddressRecord address;
-        private Optional<String> ocppIdTag;
+        private final List<OcppTagEntry> ocppTagEntries;
     }
+
+    @Getter
+    @RequiredArgsConstructor
+    public static final class OcppTagEntry {
+        private final Integer ocppTagPk;
+        private final String idTag;
+    }
+
 }

--- a/src/main/java/de/rwth/idsg/steve/repository/impl/OcppTagRepositoryImpl.java
+++ b/src/main/java/de/rwth/idsg/steve/repository/impl/OcppTagRepositoryImpl.java
@@ -48,6 +48,7 @@ import static de.rwth.idsg.steve.utils.DateTimeUtils.humanize;
 import static de.rwth.idsg.steve.utils.DateTimeUtils.toDateTime;
 import static jooq.steve.db.tables.OcppTag.OCPP_TAG;
 import static jooq.steve.db.tables.OcppTagActivity.OCPP_TAG_ACTIVITY;
+import static jooq.steve.db.tables.UserOcppTag.USER_OCPP_TAG;
 
 /**
  * @author Sevket Goekay <sevketgokay@gmail.com>
@@ -159,6 +160,16 @@ public class OcppTagRepositoryImpl implements OcppTagRepository {
         return ctx.select(OCPP_TAG.ID_TAG)
                   .from(OCPP_TAG)
                   .fetch(OCPP_TAG.ID_TAG);
+    }
+
+    @Override
+    public List<String> getIdTagsWithoutUser() {
+        return ctx.select(OCPP_TAG.ID_TAG)
+            .from(OCPP_TAG)
+            .leftJoin(USER_OCPP_TAG).on(OCPP_TAG.OCPP_TAG_PK.eq(USER_OCPP_TAG.OCPP_TAG_PK))
+            .where(USER_OCPP_TAG.OCPP_TAG_PK.isNull())
+            .orderBy(OCPP_TAG.ID_TAG)
+            .fetch(OCPP_TAG.ID_TAG);
     }
 
     @Override

--- a/src/main/java/de/rwth/idsg/steve/repository/impl/UserRepositoryImpl.java
+++ b/src/main/java/de/rwth/idsg/steve/repository/impl/UserRepositoryImpl.java
@@ -18,32 +18,35 @@
  */
 package de.rwth.idsg.steve.repository.impl;
 
+import com.google.common.base.Strings;
 import de.rwth.idsg.steve.SteveException;
 import de.rwth.idsg.steve.repository.AddressRepository;
 import de.rwth.idsg.steve.repository.UserRepository;
 import de.rwth.idsg.steve.repository.dto.User;
 import de.rwth.idsg.steve.web.dto.UserForm;
 import de.rwth.idsg.steve.web.dto.UserQueryForm;
-import jooq.steve.db.tables.records.AddressRecord;
 import jooq.steve.db.tables.records.UserRecord;
 import lombok.extern.slf4j.Slf4j;
+import org.jooq.Condition;
 import org.jooq.DSLContext;
 import org.jooq.Field;
-import org.jooq.JoinType;
 import org.jooq.Record1;
-import org.jooq.Record7;
+import org.jooq.Record5;
 import org.jooq.Result;
 import org.jooq.SelectConditionStep;
-import org.jooq.SelectQuery;
 import org.jooq.exception.DataAccessException;
 import org.jooq.impl.DSL;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Repository;
+import org.springframework.util.CollectionUtils;
 
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
-import java.util.Optional;
+import java.util.Map;
 
 import static de.rwth.idsg.steve.utils.CustomDSL.includes;
+import static jooq.steve.db.Tables.USER_OCPP_TAG;
 import static jooq.steve.db.tables.OcppTag.OCPP_TAG;
 import static jooq.steve.db.tables.User.USER;
 
@@ -60,25 +63,21 @@ public class UserRepositoryImpl implements UserRepository {
 
     @Override
     public List<User.Overview> getOverview(UserQueryForm form) {
+        var ocppTagsPerUser = getOcppTagsInternal(form.getUserPk(), form.getOcppIdTag());
+
         return getOverviewInternal(form)
                 .map(r -> User.Overview.builder()
                                        .userPk(r.value1())
-                                       .ocppTagPk(r.value2())
-                                       .ocppIdTag(r.value3())
-                                       .name(r.value4() + " " + r.value5())
-                                       .phone(r.value6())
-                                       .email(r.value7())
+                                       .name(r.value2() + " " + r.value3())
+                                       .phone(r.value4())
+                                       .email(r.value5())
+                                       .ocppTagEntries(ocppTagsPerUser.getOrDefault(r.value1(), List.of()))
                                        .build()
                 );
     }
 
     @Override
     public User.Details getDetails(int userPk) {
-
-        // -------------------------------------------------------------------------
-        // 1. user table
-        // -------------------------------------------------------------------------
-
         UserRecord ur = ctx.selectFrom(USER)
                            .where(USER.USER_PK.equal(userPk))
                            .fetchOne();
@@ -87,32 +86,10 @@ public class UserRepositoryImpl implements UserRepository {
             throw new SteveException("There is no user with id '%s'", userPk);
         }
 
-        // -------------------------------------------------------------------------
-        // 2. address table
-        // -------------------------------------------------------------------------
-
-        AddressRecord ar = addressRepository.get(ctx, ur.getAddressPk());
-
-        // -------------------------------------------------------------------------
-        // 3. ocpp_tag table
-        // -------------------------------------------------------------------------
-
-        String ocppIdTag = null;
-        if (ur.getOcppTagPk() != null) {
-            Record1<String> record = ctx.select(OCPP_TAG.ID_TAG)
-                                        .from(OCPP_TAG)
-                                        .where(OCPP_TAG.OCPP_TAG_PK.eq(ur.getOcppTagPk()))
-                                        .fetchOne();
-
-            if (record != null) {
-                ocppIdTag = record.value1();
-            }
-        }
-
         return User.Details.builder()
                            .userRecord(ur)
-                           .address(ar)
-                           .ocppIdTag(Optional.ofNullable(ocppIdTag))
+                           .address(addressRepository.get(ctx, ur.getAddressPk()))
+                           .ocppTagEntries(getOcppTagsInternal(userPk, null).getOrDefault(userPk, List.of()))
                            .build();
     }
 
@@ -122,7 +99,8 @@ public class UserRepositoryImpl implements UserRepository {
             DSLContext ctx = DSL.using(configuration);
             try {
                 Integer addressId = addressRepository.updateOrInsert(ctx, form.getAddress());
-                addInternal(ctx, form, addressId);
+                Integer userPk = addInternal(ctx, form, addressId);
+                refreshOcppTagsInternal(ctx, form, userPk);
 
             } catch (DataAccessException e) {
                 throw new SteveException("Failed to add the user", e);
@@ -137,6 +115,7 @@ public class UserRepositoryImpl implements UserRepository {
             try {
                 Integer addressId = addressRepository.updateOrInsert(ctx, form.getAddress());
                 updateInternal(ctx, form, addressId);
+                refreshOcppTagsInternal(ctx, form, form.getUserPk());
 
             } catch (DataAccessException e) {
                 throw new SteveException("Failed to update the user", e);
@@ -162,44 +141,63 @@ public class UserRepositoryImpl implements UserRepository {
     // Private helpers
     // -------------------------------------------------------------------------
 
-    @SuppressWarnings("unchecked")
-    private Result<Record7<Integer, Integer, String, String, String, String, String>> getOverviewInternal(UserQueryForm form) {
-        SelectQuery selectQuery = ctx.selectQuery();
-        selectQuery.addFrom(USER);
-        selectQuery.addJoin(OCPP_TAG, JoinType.LEFT_OUTER_JOIN, USER.OCPP_TAG_PK.eq(OCPP_TAG.OCPP_TAG_PK));
-        selectQuery.addSelect(
-                USER.USER_PK,
-                USER.OCPP_TAG_PK,
-                OCPP_TAG.ID_TAG,
-                USER.FIRST_NAME,
-                USER.LAST_NAME,
-                USER.PHONE,
-                USER.E_MAIL
-        );
+    private Result<Record5<Integer, String, String, String, String>> getOverviewInternal(UserQueryForm form) {
+        List<Condition> conditions = new ArrayList<>();
 
         if (form.isSetUserPk()) {
-            selectQuery.addConditions(USER.USER_PK.eq(form.getUserPk()));
-        }
-
-        if (form.isSetOcppIdTag()) {
-            selectQuery.addConditions(includes(OCPP_TAG.ID_TAG, form.getOcppIdTag()));
+            conditions.add(USER.USER_PK.eq(form.getUserPk()));
         }
 
         if (form.isSetEmail()) {
-            selectQuery.addConditions(includes(USER.E_MAIL, form.getEmail()));
+            conditions.add(includes(USER.E_MAIL, form.getEmail()));
         }
 
         if (form.isSetName()) {
-
             // Concatenate the two columns and search within the resulting representation
             // for flexibility, since the user can search by first or last name, or both.
             Field<String> joinedField = DSL.concat(USER.FIRST_NAME, USER.LAST_NAME);
 
             // Find a matching sequence anywhere within the concatenated representation
-            selectQuery.addConditions(includes(joinedField, form.getName()));
+            conditions.add(includes(joinedField, form.getName()));
         }
 
-        return selectQuery.fetch();
+        return ctx.select(
+                USER.USER_PK,
+                USER.FIRST_NAME,
+                USER.LAST_NAME,
+                USER.PHONE,
+                USER.E_MAIL)
+            .from(USER)
+            .where(conditions)
+            .fetch();
+    }
+
+    private Map<Integer, List<User.OcppTagEntry>> getOcppTagsInternal(Integer userPk, String ocppIdTag) {
+        List<Condition> conditions = new ArrayList<>();
+
+        if (userPk != null) {
+            conditions.add(USER_OCPP_TAG.USER_PK.eq(userPk));
+        }
+
+        if (!Strings.isNullOrEmpty(ocppIdTag)) {
+            conditions.add(includes(OCPP_TAG.ID_TAG, ocppIdTag));
+        }
+
+        var results = ctx.select(
+                USER_OCPP_TAG.USER_PK,
+                OCPP_TAG.OCPP_TAG_PK,
+                OCPP_TAG.ID_TAG)
+            .from(USER_OCPP_TAG)
+            .join(OCPP_TAG).on(USER_OCPP_TAG.OCPP_TAG_PK.eq(OCPP_TAG.OCPP_TAG_PK))
+            .where(conditions)
+            .fetch();
+
+        Map<Integer, List<User.OcppTagEntry>> map = new HashMap<>();
+        for (var entry : results) {
+            map.computeIfAbsent(entry.value1(), k -> new ArrayList<>())
+                .add(new User.OcppTagEntry(entry.value2(), entry.value3()));
+        }
+        return map;
     }
 
     private SelectConditionStep<Record1<Integer>> selectAddressId(int userPk) {
@@ -214,21 +212,22 @@ public class UserRepositoryImpl implements UserRepository {
                   .where(OCPP_TAG.ID_TAG.eq(ocppIdTag));
     }
 
-    private void addInternal(DSLContext ctx, UserForm form, Integer addressPk) {
-        int count = ctx.insertInto(USER)
-                       .set(USER.FIRST_NAME, form.getFirstName())
-                       .set(USER.LAST_NAME, form.getLastName())
-                       .set(USER.BIRTH_DAY, form.getBirthDay())
-                       .set(USER.SEX, form.getSex().getDatabaseValue())
-                       .set(USER.PHONE, form.getPhone())
-                       .set(USER.E_MAIL, form.getEMail())
-                       .set(USER.NOTE, form.getNote())
-                       .set(USER.ADDRESS_PK, addressPk)
-                       .set(USER.OCPP_TAG_PK, selectOcppTagPk(form.getOcppIdTag()))
-                       .execute();
-
-        if (count != 1) {
-            throw new SteveException("Failed to insert the user");
+    private Integer addInternal(DSLContext ctx, UserForm form, Integer addressPk) {
+        try {
+            return ctx.insertInto(USER)
+                      .set(USER.FIRST_NAME, form.getFirstName())
+                      .set(USER.LAST_NAME, form.getLastName())
+                      .set(USER.BIRTH_DAY, form.getBirthDay())
+                      .set(USER.SEX, form.getSex().getDatabaseValue())
+                      .set(USER.PHONE, form.getPhone())
+                      .set(USER.E_MAIL, form.getEMail())
+                      .set(USER.NOTE, form.getNote())
+                      .set(USER.ADDRESS_PK, addressPk)
+                      .returning(USER.USER_PK)
+                      .fetchOne()
+                      .getUserPk();
+        } catch (DataAccessException e) {
+            throw new SteveException("Failed to insert the user", e);
         }
     }
 
@@ -242,7 +241,6 @@ public class UserRepositoryImpl implements UserRepository {
            .set(USER.E_MAIL, form.getEMail())
            .set(USER.NOTE, form.getNote())
            .set(USER.ADDRESS_PK, addressPk)
-           .set(USER.OCPP_TAG_PK, selectOcppTagPk(form.getOcppIdTag()))
            .where(USER.USER_PK.eq(form.getUserPk()))
            .execute();
     }
@@ -251,5 +249,38 @@ public class UserRepositoryImpl implements UserRepository {
         ctx.delete(USER)
            .where(USER.USER_PK.equal(userPk))
            .execute();
+    }
+
+    /**
+     * Refresh the full the OCPP tag associations for a user:
+     * - 1. Delete existing OCPP tags that are not in the form.
+     * - 2. Insert new OCPP tags from the form that do not already exist for the user.
+     */
+    private void refreshOcppTagsInternal(DSLContext ctx, UserForm form, Integer userPk) {
+        List<Integer> wantedOcppTagPks = CollectionUtils.isEmpty(form.getIdTagList())
+            ? List.of() // This user wants no OCPP tags
+            : ctx.select(OCPP_TAG.OCPP_TAG_PK)
+            .from(OCPP_TAG)
+            .where(OCPP_TAG.ID_TAG.in(form.getIdTagList()))
+            .fetch(OCPP_TAG.OCPP_TAG_PK);
+
+        // Optimization: Execute the delete query only if we are processing an existing user.
+        // A new user will not have any existing OCPP tags, so no delete is needed.
+        //
+        // 1. Delete entries that are not in the wanted entries
+        if (form.getUserPk() != null) {
+            ctx.deleteFrom(USER_OCPP_TAG)
+                .where(USER_OCPP_TAG.USER_PK.eq(userPk))
+                .and(USER_OCPP_TAG.OCPP_TAG_PK.notIn(wantedOcppTagPks))
+                .execute();
+        }
+
+        // 2. Insert new entries that are not already present
+        if (!wantedOcppTagPks.isEmpty()) {
+            ctx.insertInto(USER_OCPP_TAG, USER_OCPP_TAG.USER_PK, USER_OCPP_TAG.OCPP_TAG_PK)
+                .valuesOfRows(wantedOcppTagPks.stream().map(pk -> DSL.row(userPk, pk)).toList())
+                .onDuplicateKeyIgnore() // Ignore if already exists
+                .execute();
+        }
     }
 }

--- a/src/main/java/de/rwth/idsg/steve/service/OcppTagService.java
+++ b/src/main/java/de/rwth/idsg/steve/service/OcppTagService.java
@@ -67,6 +67,10 @@ public class OcppTagService {
         return ocppTagRepository.getIdTags();
     }
 
+    public List<String> getIdTagsWithoutUser() {
+        return ocppTagRepository.getIdTagsWithoutUser();
+    }
+
     public List<String> getActiveIdTags() {
         return ocppTagRepository.getActiveIdTags();
     }

--- a/src/main/java/de/rwth/idsg/steve/utils/mapper/UserFormMapper.java
+++ b/src/main/java/de/rwth/idsg/steve/utils/mapper/UserFormMapper.java
@@ -19,7 +19,6 @@
 package de.rwth.idsg.steve.utils.mapper;
 
 import de.rwth.idsg.steve.repository.dto.User;
-import de.rwth.idsg.steve.utils.ControllerHelper;
 import de.rwth.idsg.steve.web.dto.UserForm;
 import de.rwth.idsg.steve.web.dto.UserSex;
 import jooq.steve.db.tables.records.UserRecord;
@@ -46,7 +45,7 @@ public final class UserFormMapper {
         form.setEMail(userRecord.getEMail());
         form.setNote(userRecord.getNote());
         form.setAddress(AddressMapper.recordToDto(details.getAddress()));
-        form.setOcppIdTag(details.getOcppIdTag().orElse(ControllerHelper.EMPTY_OPTION));
+        form.setIdTagList(details.getOcppTagEntries().stream().map(User.OcppTagEntry::getIdTag).toList());
 
         return form;
     }

--- a/src/main/java/de/rwth/idsg/steve/web/controller/UsersController.java
+++ b/src/main/java/de/rwth/idsg/steve/web/controller/UsersController.java
@@ -36,6 +36,9 @@ import org.springframework.web.bind.annotation.RequestMethod;
 
 import jakarta.validation.Valid;
 
+import java.util.ArrayList;
+import java.util.List;
+
 /**
  * @author Sevket Goekay <sevketgokay@gmail.com>
  * @since 25.11.2015
@@ -87,13 +90,13 @@ public class UsersController {
         UserForm form = UserFormMapper.toForm(details);
 
         model.addAttribute("userForm", form);
-        setTags(model);
+        setTags(model, form.getIdTagList());
         return "data-man/userDetails";
     }
 
     @RequestMapping(value = ADD_PATH, method = RequestMethod.GET)
     public String addGet(Model model) {
-        setTags(model);
+        setTags(model, List.of());
         model.addAttribute("userForm", new UserForm());
         return "data-man/userAdd";
     }
@@ -102,7 +105,7 @@ public class UsersController {
     public String addPost(@Valid @ModelAttribute("userForm") UserForm userForm,
                           BindingResult result, Model model) {
         if (result.hasErrors()) {
-            setTags(model);
+            setTags(model, userForm.getIdTagList());
             return "data-man/userAdd";
         }
 
@@ -114,7 +117,7 @@ public class UsersController {
     public String update(@Valid @ModelAttribute("userForm") UserForm userForm,
                          BindingResult result, Model model) {
         if (result.hasErrors()) {
-            setTags(model);
+            setTags(model, userForm.getIdTagList());
             return "data-man/userDetails";
         }
 
@@ -128,9 +131,16 @@ public class UsersController {
         return toOverview();
     }
 
-    private void setTags(Model model) {
+    private void setTags(Model model, List<String> idTagsFromUser) {
+        List<String> fromDB = ocppTagService.getIdTagsWithoutUser();
+
+        // new temp list because we want to have a specific order
+        List<String> idTagList = new ArrayList<>(fromDB.size() + idTagsFromUser.size());
+        idTagList.addAll(idTagsFromUser);
+        idTagList.addAll(fromDB);
+
         model.addAttribute("countryCodes", ControllerHelper.COUNTRY_DROPDOWN);
-        model.addAttribute("idTagList", ControllerHelper.idTagEnhancer(ocppTagService.getIdTags()));
+        model.addAttribute("idTagList", idTagList);
     }
 
     // -------------------------------------------------------------------------

--- a/src/main/java/de/rwth/idsg/steve/web/controller/UsersController.java
+++ b/src/main/java/de/rwth/idsg/steve/web/controller/UsersController.java
@@ -25,14 +25,11 @@ import de.rwth.idsg.steve.utils.ControllerHelper;
 import de.rwth.idsg.steve.utils.mapper.UserFormMapper;
 import de.rwth.idsg.steve.web.dto.UserForm;
 import de.rwth.idsg.steve.web.dto.UserQueryForm;
-import org.springframework.beans.factory.annotation.Autowired;
+import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.validation.BindingResult;
-import org.springframework.web.bind.annotation.ModelAttribute;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.*;
 
 import jakarta.validation.Valid;
 
@@ -43,12 +40,13 @@ import java.util.List;
  * @author Sevket Goekay <sevketgokay@gmail.com>
  * @since 25.11.2015
  */
+@AllArgsConstructor
 @Controller
 @RequestMapping(value = "/manager/users")
 public class UsersController {
 
-    @Autowired private OcppTagService ocppTagService;
-    @Autowired private UserRepository userRepository;
+    private final OcppTagService ocppTagService;
+    private final UserRepository userRepository;
 
     private static final String PARAMS = "params";
 
@@ -67,13 +65,13 @@ public class UsersController {
     // HTTP methods
     // -------------------------------------------------------------------------
 
-    @RequestMapping(method = RequestMethod.GET)
+    @GetMapping
     public String getOverview(Model model) {
         initList(model, new UserQueryForm());
         return "data-man/users";
     }
 
-    @RequestMapping(value = QUERY_PATH, method = RequestMethod.GET)
+    @GetMapping(value = QUERY_PATH)
     public String getQuery(@ModelAttribute(PARAMS) UserQueryForm params, Model model) {
         initList(model, params);
         return "data-man/users";
@@ -84,9 +82,9 @@ public class UsersController {
         model.addAttribute("userList", userRepository.getOverview(params));
     }
 
-    @RequestMapping(value = DETAILS_PATH, method = RequestMethod.GET)
+    @GetMapping(value = DETAILS_PATH)
     public String getDetails(@PathVariable("userPk") int userPk, Model model) {
-        User.Details details = userRepository.getDetails(userPk);
+        var details = userRepository.getDetails(userPk);
         UserForm form = UserFormMapper.toForm(details);
 
         model.addAttribute("userForm", form);
@@ -94,14 +92,14 @@ public class UsersController {
         return "data-man/userDetails";
     }
 
-    @RequestMapping(value = ADD_PATH, method = RequestMethod.GET)
+    @GetMapping(value = ADD_PATH)
     public String addGet(Model model) {
         setTags(model, List.of());
         model.addAttribute("userForm", new UserForm());
         return "data-man/userAdd";
     }
 
-    @RequestMapping(params = "add", value = ADD_PATH, method = RequestMethod.POST)
+    @PostMapping(params = "add", value = ADD_PATH)
     public String addPost(@Valid @ModelAttribute("userForm") UserForm userForm,
                           BindingResult result, Model model) {
         if (result.hasErrors()) {
@@ -113,7 +111,7 @@ public class UsersController {
         return toOverview();
     }
 
-    @RequestMapping(params = "update", value = UPDATE_PATH, method = RequestMethod.POST)
+    @PostMapping(params = "update", value = UPDATE_PATH)
     public String update(@Valid @ModelAttribute("userForm") UserForm userForm,
                          BindingResult result, Model model) {
         if (result.hasErrors()) {
@@ -125,17 +123,17 @@ public class UsersController {
         return toOverview();
     }
 
-    @RequestMapping(value = DELETE_PATH, method = RequestMethod.POST)
+    @PostMapping(value = DELETE_PATH)
     public String delete(@PathVariable("userPk") int userPk) {
         userRepository.delete(userPk);
         return toOverview();
     }
 
     private void setTags(Model model, List<String> idTagsFromUser) {
-        List<String> fromDB = ocppTagService.getIdTagsWithoutUser();
+        var fromDB = ocppTagService.getIdTagsWithoutUser();
 
         // new temp list because we want to have a specific order
-        List<String> idTagList = new ArrayList<>(fromDB.size() + idTagsFromUser.size());
+        var idTagList = new ArrayList<>(fromDB.size() + idTagsFromUser.size());
         idTagList.addAll(idTagsFromUser);
         idTagList.addAll(fromDB);
 
@@ -147,17 +145,17 @@ public class UsersController {
     // Back to Overview
     // -------------------------------------------------------------------------
 
-    @RequestMapping(params = "backToOverview", value = ADD_PATH, method = RequestMethod.POST)
+    @PostMapping(params = "backToOverview", value = ADD_PATH)
     public String addBackToOverview() {
         return toOverview();
     }
 
-    @RequestMapping(params = "backToOverview", value = UPDATE_PATH, method = RequestMethod.POST)
+    @PostMapping(params = "backToOverview", value = UPDATE_PATH)
     public String updateBackToOverview() {
         return toOverview();
     }
 
-    private String toOverview() {
+    private static String toOverview() {
         return "redirect:/manager/users";
     }
 }

--- a/src/main/java/de/rwth/idsg/steve/web/dto/UserForm.java
+++ b/src/main/java/de/rwth/idsg/steve/web/dto/UserForm.java
@@ -26,6 +26,9 @@ import org.joda.time.LocalDate;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotNull;
 
+import java.util.Collections;
+import java.util.List;
+
 /**
  * @author Sevket Goekay <sevketgokay@gmail.com>
  * @since 25.11.2015
@@ -38,7 +41,7 @@ public class UserForm {
     // Internal database id
     private Integer userPk;
 
-    private String ocppIdTag;
+    private List<String> idTagList = Collections.emptyList();
 
     private String firstName;
     private String lastName;

--- a/src/main/java/de/rwth/idsg/steve/web/dto/UserForm.java
+++ b/src/main/java/de/rwth/idsg/steve/web/dto/UserForm.java
@@ -26,7 +26,6 @@ import org.joda.time.LocalDate;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotNull;
 
-import java.util.Collections;
 import java.util.List;
 
 /**
@@ -41,7 +40,8 @@ public class UserForm {
     // Internal database id
     private Integer userPk;
 
-    private List<String> idTagList = Collections.emptyList();
+    @NotNull
+    private List<String> idTagList;
 
     private String firstName;
     private String lastName;
@@ -56,5 +56,4 @@ public class UserForm {
     private String eMail;
 
     private Address address;
-
 }

--- a/src/main/resources/db/migration/V1_0_8__update.sql
+++ b/src/main/resources/db/migration/V1_0_8__update.sql
@@ -1,0 +1,37 @@
+START TRANSACTION;
+
+-- 1. create user_ocpp_tag table where a user can have multiple ocpp_tags
+CREATE TABLE user_ocpp_tag
+(
+    user_pk int(11) NOT NULL,
+    ocpp_tag_pk int(11) NOT NULL,
+
+    PRIMARY KEY (user_pk, ocpp_tag_pk),
+
+    -- ensure that each ocpp_tag can only be assigned to one user
+    --
+    -- IMPORTANT! previous ocpp_tag_pk column in user table was not unique (more than one user could have
+    -- the same ocpp_tag), so this is a change.
+    --
+    UNIQUE (ocpp_tag_pk),
+
+    FOREIGN KEY (user_pk) REFERENCES user(user_pk) ON DELETE CASCADE,
+    FOREIGN KEY (ocpp_tag_pk) REFERENCES ocpp_tag(ocpp_tag_pk) ON DELETE CASCADE
+);
+
+-- 2. move data from user table to user_ocpp_tag table
+--
+-- IMPORTANT! this will fail if there are multiple users with the same ocpp_tag_pk (see above).
+-- if you have such data, you need to resolve it before running this migration. we are not making any assumptions or
+-- decisions about which user should keep the ocpp_tag (which might be a very problematic assumption), so we just fail
+-- the migration.
+--
+INSERT INTO user_ocpp_tag (user_pk, ocpp_tag_pk)
+SELECT user_pk, ocpp_tag_pk FROM user WHERE ocpp_tag_pk IS NOT NULL;
+
+-- 3. now that we moved the data, drop redundant columns
+ALTER TABLE user
+    DROP FOREIGN KEY FK_user_ocpp_tag_otpk,
+    DROP COLUMN ocpp_tag_pk;
+
+COMMIT;

--- a/src/main/resources/db/migration/V1_0_8__update.sql
+++ b/src/main/resources/db/migration/V1_0_8__update.sql
@@ -1,5 +1,3 @@
-START TRANSACTION;
-
 -- 1. create user_ocpp_tag table where a user can have multiple ocpp_tags
 CREATE TABLE user_ocpp_tag
 (
@@ -33,5 +31,3 @@ SELECT user_pk, ocpp_tag_pk FROM user WHERE ocpp_tag_pk IS NOT NULL;
 ALTER TABLE user
     DROP FOREIGN KEY FK_user_ocpp_tag_otpk,
     DROP COLUMN ocpp_tag_pk;
-
-COMMIT;

--- a/src/main/resources/webapp/WEB-INF/views/data-man/00-user-ocpp.jsp
+++ b/src/main/resources/webapp/WEB-INF/views/data-man/00-user-ocpp.jsp
@@ -20,7 +20,7 @@
 --%>
 <%@ taglib prefix="form" uri="http://www.springframework.org/tags/form" %>
 <table class="userInput">
-	<thead><tr><th>OCPP ID Tags</th><th></th></thead>
+  <thead><tr><th>OCPP ID Tags</th><th></th></tr></thead>
 	<tbody>
 	<tr>
 		<td style="vertical-align:top">
@@ -28,9 +28,7 @@
 		</td>
 		<td>
 			<form:select path="idTagList" size="5" multiple="true">
-				<c:forEach items="${idTagList}" var="idTag">
-					<form:option value="${idTag}" label="${idTag}"/>
-				</c:forEach>
+				<form:options items="${idTagList}"/>
 			</form:select>
 		</td>
 	</tr>

--- a/src/main/resources/webapp/WEB-INF/views/data-man/00-user-ocpp.jsp
+++ b/src/main/resources/webapp/WEB-INF/views/data-man/00-user-ocpp.jsp
@@ -20,11 +20,19 @@
 --%>
 <%@ taglib prefix="form" uri="http://www.springframework.org/tags/form" %>
 <table class="userInput">
-	<thead><tr><th>OCPP</th><th></th></thead>
+	<thead><tr><th>OCPP ID Tags</th><th></th></thead>
 	<tbody>
 	<tr>
-		<td>OCPP ID Tag:</td>
-		<td><form:select path="ocppIdTag" items="${idTagList}" /></td>
+		<td style="vertical-align:top">
+			<input type="button" value="Select None" onClick="selectNone(document.getElementById('idTagList'))">
+		</td>
+		<td>
+			<form:select path="idTagList" size="5" multiple="true">
+				<c:forEach items="${idTagList}" var="idTag">
+					<form:option value="${idTag}" label="${idTag}"/>
+				</c:forEach>
+			</form:select>
+		</td>
 	</tr>
 	<tr><td></td>
 		<td id="add_space">

--- a/src/main/resources/webapp/WEB-INF/views/data-man/users.jsp
+++ b/src/main/resources/webapp/WEB-INF/views/data-man/users.jsp
@@ -57,7 +57,7 @@
         <thead>
             <tr>
                 <th data-sort="int">User ID</th>
-                <th data-sort="string">Ocpp ID Tag</th>
+                <th data-sort="string">Ocpp ID Tags</th>
                 <th data-sort="string">Name</th>
                 <th data-sort="string">Phone</th>
                 <th data-sort="string">E-Mail</th>
@@ -72,9 +72,9 @@
         <c:forEach items="${userList}" var="cr">
             <tr><td><a href="${ctxPath}/manager/users/details/${cr.userPk}">${cr.userPk}</a></td>
                 <td>
-                    <c:if test="${not empty cr.ocppIdTag}">
-                        <a href="${ctxPath}/manager/ocppTags/details/${cr.ocppTagPk}">${cr.ocppIdTag}</a>
-                    </c:if>
+                    <c:forEach var="it" items="${cr.ocppTagEntries}" varStatus="loop">
+                        <a href="${ctxPath}/manager/ocppTags/details/${it.ocppTagPk}">${it.idTag}</a>${loop.last ? '' : ', '}
+                    </c:forEach>
                 </td>
                 <td>${cr.name}</td>
                 <td>${cr.phone}</td>

--- a/src/main/resources/webapp/WEB-INF/views/data-man/users.jsp
+++ b/src/main/resources/webapp/WEB-INF/views/data-man/users.jsp
@@ -73,7 +73,7 @@
             <tr><td><a href="${ctxPath}/manager/users/details/${cr.userPk}">${cr.userPk}</a></td>
                 <td>
                     <c:forEach var="it" items="${cr.ocppTagEntries}" varStatus="loop">
-                        <a href="${ctxPath}/manager/ocppTags/details/${it.ocppTagPk}">${it.idTag}</a>${loop.last ? '' : ', '}
+                        <a href="${ctxPath}/manager/ocppTags/details/${it.ocppTagPk}"><c:out value="${it.idTag}"/></a>${loop.last ? '' : ', '}
                     </c:forEach>
                 </td>
                 <td>${cr.name}</td>


### PR DESCRIPTION
Backport https://github.com/steve-community/steve/pull/1777

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Assign multiple OCPP ID tags to a user via a new multi-select UI.
  - “Select None” button to quickly clear selected tags.
  - Users list now displays all tags per user, with links to tag details.

- Improvements
  - Tag selection preserves user input on validation errors and prioritizes entered IDs.
  - Available tag list focuses on unassigned tags for easier selection.

- Database Migration
  - Existing single-tag associations are migrated to a new user–tag mapping automatically; no user action required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->