### PR TITLE
build(deps): bump jetty.version from 12.0.18 to 12.0.27

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
     <plugin.cxf.version>4.1.3</plugin.cxf.version>
 
     <lombok.version>1.18.40</lombok.version>
-    <jetty.version>12.0.18</jetty.version>
+    <jetty.version>12.0.27</jetty.version>
     <mysql.jdbc.version>9.4.0</mysql.jdbc.version>
     <owasp-encoder.version>1.3.1</owasp-encoder.version>
     <slf4j.version>2.0.17</slf4j.version>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Upgraded the embedded web server to the latest patch release, delivering security updates, improved stability, and compatibility with newer environments.
  * Expect minor performance and reliability improvements under load.
  * No functional changes to the user interface or workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->