### PR TITLE
Upgrade Jetty to 12.1.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
     <plugin.cxf.version>4.1.3</plugin.cxf.version>
 
     <lombok.version>1.18.40</lombok.version>
-    <jetty.version>12.0.27</jetty.version>
+    <jetty.version>12.1.1</jetty.version>
     <mysql.jdbc.version>9.4.0</mysql.jdbc.version>
     <owasp-encoder.version>1.3.1</owasp-encoder.version>
     <slf4j.version>2.0.17</slf4j.version>
@@ -120,6 +120,20 @@
         <groupId>com.fasterxml.jackson</groupId>
         <artifactId>jackson-bom</artifactId>
         <version>2.20.0</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.jetty</groupId>
+        <artifactId>jetty-bom</artifactId>
+        <version>${jetty.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.jetty.ee10</groupId>
+        <artifactId>jetty-ee10-bom</artifactId>
+        <version>${jetty.version}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/steve-ui-jsp/pom.xml
+++ b/steve-ui-jsp/pom.xml
@@ -55,12 +55,10 @@
     <dependency>
       <groupId>org.eclipse.jetty.ee10</groupId>
       <artifactId>jetty-ee10-apache-jsp</artifactId>
-      <version>${jetty.version}</version>
     </dependency>
     <!--        <dependency>-->
     <!--            <groupId>org.eclipse.jetty</groupId>-->
     <!--            <artifactId>apache-jstl</artifactId>-->
-    <!--            <version>${jetty.version}</version>-->
     <!--        </dependency>-->
     <dependency>
       <groupId>org.owasp.encoder</groupId>

--- a/steve/pom.xml
+++ b/steve/pom.xml
@@ -111,27 +111,30 @@
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-server</artifactId>
-      <version>${jetty.version}</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty.ee10</groupId>
       <artifactId>jetty-ee10-webapp</artifactId>
-      <version>${jetty.version}</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty.ee10</groupId>
       <artifactId>jetty-ee10-annotations</artifactId>
-      <version>${jetty.version}</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-rewrite</artifactId>
-      <version>${jetty.version}</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty.ee10.websocket</groupId>
       <artifactId>jetty-ee10-websocket-jetty-server</artifactId>
-      <version>${jetty.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty.compression</groupId>
+      <artifactId>jetty-compression-server</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty.compression</groupId>
+      <artifactId>jetty-compression-gzip</artifactId>
     </dependency>
 
     <!-- DB -->
@@ -155,7 +158,6 @@
     <dependency>
       <groupId>org.eclipse.jetty.websocket</groupId>
       <artifactId>jetty-websocket-jetty-client</artifactId>
-      <version>${jetty.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/steve/src/main/java/de/rwth/idsg/steve/JettyServer.java
+++ b/steve/src/main/java/de/rwth/idsg/steve/JettyServer.java
@@ -126,7 +126,7 @@ public class JettyServer {
         }
 
         steveAppContext = new SteveAppContext(config, logFileRetriever, info);
-        server.setHandler(steveAppContext.getHandlers());
+        server.setHandler(steveAppContext.getHandler());
     }
 
     private ServerConnector httpConnector(HttpConfiguration httpconfig) {

--- a/steve/src/main/java/de/rwth/idsg/steve/JettyServer.java
+++ b/steve/src/main/java/de/rwth/idsg/steve/JettyServer.java
@@ -186,6 +186,7 @@ public class JettyServer {
     public void stop() throws Exception {
         if (server != null) {
             server.stop();
+            steveAppContext.close();
         }
     }
 

--- a/steve/src/main/java/de/rwth/idsg/steve/SteveAppContext.java
+++ b/steve/src/main/java/de/rwth/idsg/steve/SteveAppContext.java
@@ -23,6 +23,8 @@ import de.rwth.idsg.steve.web.dto.EndpointInfo;
 import org.apache.cxf.transport.servlet.CXFServlet;
 import org.apache.tomcat.InstanceManager;
 import org.apache.tomcat.SimpleInstanceManager;
+import org.eclipse.jetty.compression.gzip.GzipCompression;
+import org.eclipse.jetty.compression.server.CompressionHandler;
 import org.eclipse.jetty.ee10.apache.jsp.JettyJasperInitializer;
 import org.eclipse.jetty.ee10.servlet.FilterHolder;
 import org.eclipse.jetty.ee10.servlet.ServletContextHandler;
@@ -34,7 +36,6 @@ import org.eclipse.jetty.rewrite.handler.RewriteHandler;
 import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.handler.ContextHandler;
 import org.eclipse.jetty.server.handler.ContextHandlerCollection;
-import org.eclipse.jetty.server.handler.gzip.GzipHandler;
 import org.eclipse.jetty.util.component.AbstractLifeCycle;
 import org.eclipse.jetty.websocket.core.WebSocketConstants;
 import org.springframework.context.support.GenericApplicationContext;
@@ -97,8 +98,9 @@ public class SteveAppContext {
         }
 
         // Wraps the whole web app in a gzip handler to make Jetty return compressed content
-        // http://www.eclipse.org/jetty/documentation/current/gzip-filter.html
-        return new GzipHandler(webAppContext);
+        var handler = new CompressionHandler(webAppContext);
+        handler.putCompression(new GzipCompression());
+        return handler;
     }
 
     private WebAppContext initWebApp() {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Performance
  - Improved HTTP response compression for smaller payloads and faster page loads; respects gzip configuration and can be applied per-site.

- Chores
  - Upgraded server runtime to Jetty 12.1.1 with centralized version management for consistent modules.

- New Features
  - Added configurable redirect rules for client requests.

- Refactor
  - Streamlined webapp resource initialization and lifecycle handling for more reliable startup/shutdown.

- Bug Fixes
  - More reliable embedded JSP startup and improved cleanup on shutdown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->