### PR TITLE
Enhance RemoteStartTransactionTask to support charging profiles and transaction IDs

### DIFF
--- a/steve-core/src/main/java/de/rwth/idsg/steve/service/ChargePointServiceClient.java
+++ b/steve-core/src/main/java/de/rwth/idsg/steve/service/ChargePointServiceClient.java
@@ -189,14 +189,14 @@ public class ChargePointServiceClient {
     // -------------------------------------------------------------------------
     @SafeVarargs
     public final int remoteStartTransaction(RemoteStartTransactionParams params, OcppCallback<String>... callbacks) {
-        RemoteStartTransactionTask task = new RemoteStartTransactionTask(params);
+        RemoteStartTransactionTask task = new RemoteStartTransactionTask(params, chargingProfileRepository);
         return addRemoteStartTask(task, callbacks);
     }
 
     @SafeVarargs
     public final int remoteStartTransaction(
             RemoteStartTransactionParams params, String caller, OcppCallback<String>... callbacks) {
-        RemoteStartTransactionTask task = new RemoteStartTransactionTask(params, caller);
+        RemoteStartTransactionTask task = new RemoteStartTransactionTask(params, caller, chargingProfileRepository);
         return addRemoteStartTask(task, callbacks);
     }
 

--- a/steve-core/src/main/java/de/rwth/idsg/steve/web/dto/ocpp/RemoteStartTransactionParams.java
+++ b/steve-core/src/main/java/de/rwth/idsg/steve/web/dto/ocpp/RemoteStartTransactionParams.java
@@ -25,19 +25,22 @@ import org.jspecify.annotations.Nullable;
 
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Positive;
 
 /**
  * @author Sevket Goekay <sevketgokay@gmail.com>
  * @since 01.01.2015
  */
 @Getter
+@Setter
 public class RemoteStartTransactionParams extends SingleChargePointSelect {
 
     @Min(value = 0, message = "Connector ID must be at least {value}") @Nullable private Integer connectorId;
 
     @NotBlank(message = "User ID Tag is required") @IdTag
-    @Setter
     private String idTag;
+
+    @Positive private @Nullable Integer chargingProfilePk;
 
     /**
      * Not for a specific connector, when frontend sends the value 0.

--- a/steve-core/src/main/java/de/rwth/idsg/steve/web/dto/ocpp/SetChargingProfileParams.java
+++ b/steve-core/src/main/java/de/rwth/idsg/steve/web/dto/ocpp/SetChargingProfileParams.java
@@ -36,4 +36,6 @@ public class SetChargingProfileParams extends MultipleChargePointSelect {
     @NotNull @Min(value = 0, message = "Connector ID must be at least {value}") private Integer connectorId;
 
     @NotNull @Positive private Integer chargingProfilePk;
+
+    @Positive private Integer transactionId;
 }

--- a/steve-ui-jsp/src/main/java/de/rwth/idsg/steve/web/controller/Ocpp12Controller.java
+++ b/steve-ui-jsp/src/main/java/de/rwth/idsg/steve/web/controller/Ocpp12Controller.java
@@ -82,6 +82,14 @@ public class Ocpp12Controller {
     // Helpers
     // -------------------------------------------------------------------------
 
+    /**
+     * https://github.com/steve-community/steve/issues/1759
+     * used to create form in order to send charging profile within remote start tx for ocpp 1.6.
+     */
+    protected void setCommonAttributesForRemoteStartTx(Model model) {
+        // nothing to do for versions below 1.6
+    }
+
     protected void setCommonAttributesForTx(Model model) {
         setCommonAttributes(model);
     }
@@ -150,6 +158,7 @@ public class Ocpp12Controller {
     public String getRemoteStartTx(Model model) {
         setCommonAttributesForTx(model);
         setActiveUserIdTagList(model);
+        setCommonAttributesForRemoteStartTx(model);
         model.addAttribute(PARAMS, new RemoteStartTransactionParams());
         return getPrefix() + REMOTE_START_TX_PATH;
     }
@@ -233,6 +242,7 @@ public class Ocpp12Controller {
         if (result.hasErrors()) {
             setCommonAttributesForTx(model);
             setActiveUserIdTagList(model);
+            setCommonAttributesForRemoteStartTx(model);
             return getPrefix() + REMOTE_START_TX_PATH;
         }
         return REDIRECT_TASKS_PATH + chargePointServiceClient.remoteStartTransaction(params);

--- a/steve-ui-jsp/src/main/java/de/rwth/idsg/steve/web/controller/Ocpp16Controller.java
+++ b/steve-ui-jsp/src/main/java/de/rwth/idsg/steve/web/controller/Ocpp16Controller.java
@@ -80,6 +80,11 @@ public class Ocpp16Controller extends Ocpp15Controller {
     // Helpers
     // -------------------------------------------------------------------------
 
+    protected void setCommonAttributesForRemoteStartTx(Model model) {
+        model.addAttribute("profileForRemoteStartTx", Boolean.TRUE);
+        model.addAttribute("profileList", chargingProfileRepository.getBasicInfo());
+    }
+
     @Override
     protected void setCommonAttributesForTx(Model model) {
         model.addAttribute("cpList", chargePointHelperService.getChargePoints(OcppVersion.V_16));

--- a/steve-ui-jsp/src/main/resources/webapp/WEB-INF/views/op-forms/RemoteStartTransactionForm.jsp
+++ b/steve-ui-jsp/src/main/resources/webapp/WEB-INF/views/op-forms/RemoteStartTransactionForm.jsp
@@ -33,6 +33,17 @@
                 </form:select>
             </td>
         </tr>
+        <c:if test="${profileForRemoteStartTx}">
+            <tr>
+                <td>Charging Profile ID:</td>
+                <td>
+                    <form:select path="chargingProfilePk">
+                        <option value="" selected>-- Empty --</option>
+                        <form:options items="${profileList}" itemLabel="itemDescription" itemValue="chargingProfilePk"/>
+                    </form:select>
+                </td>
+            </tr>
+        </c:if>
         <tr><td></td><td><div class="submit-button"><input type="submit" value="Perform"></div></td></tr>
     </table>
 </form:form>

--- a/steve-ui-jsp/src/main/resources/webapp/WEB-INF/views/op-forms/RemoteStartTransactionForm.jsp
+++ b/steve-ui-jsp/src/main/resources/webapp/WEB-INF/views/op-forms/RemoteStartTransactionForm.jsp
@@ -38,7 +38,7 @@
                 <td>Charging Profile ID:</td>
                 <td>
                     <form:select path="chargingProfilePk">
-                        <option value="" selected>-- Empty --</option>
+                        <form:option value="">-- Empty --</form:option>
                         <form:options items="${profileList}" itemLabel="itemDescription" itemValue="chargingProfilePk"/>
                     </form:select>
                 </td>

--- a/steve-ui-jsp/src/main/resources/webapp/WEB-INF/views/op-forms/SetChargingProfileForm.jsp
+++ b/steve-ui-jsp/src/main/resources/webapp/WEB-INF/views/op-forms/SetChargingProfileForm.jsp
@@ -32,11 +32,17 @@
         </tr>
         <tr>
             <td>Connector ID (integer):</td>
-            <td><form:input path="connectorId" placeholder="0 = charge point as a whole"/></td>
+            <td>
+                <form:input path="connectorId" type="number" inputmode="numeric" min="0" step="1" placeholder="0 = charge point as a whole"/>
+                <form:errors path="connectorId" cssClass="error"/>
+            </td>
         </tr>
         <tr>
             <td>Transaction ID (integer):</td>
-            <td><form:input path="transactionId" placeholder="only necessary for TxProfile"/></td>
+            <td>
+                <form:input path="transactionId" type="number" inputmode="numeric" min="1" step="1" placeholder="only necessary for TxProfile"/>
+                <form:errors path="transactionId" cssClass="error"/>
+            </td>
         </tr>
         <tr><td></td><td><div class="submit-button"><input type="submit" value="Perform"></div></td></tr>
     </table>

--- a/steve-ui-jsp/src/main/resources/webapp/WEB-INF/views/op-forms/SetChargingProfileForm.jsp
+++ b/steve-ui-jsp/src/main/resources/webapp/WEB-INF/views/op-forms/SetChargingProfileForm.jsp
@@ -34,6 +34,10 @@
             <td>Connector ID (integer):</td>
             <td><form:input path="connectorId" placeholder="0 = charge point as a whole"/></td>
         </tr>
+        <tr>
+            <td>Transaction ID (integer):</td>
+            <td><form:input path="transactionId" placeholder="only necessary for TxProfile"/></td>
+        </tr>
         <tr><td></td><td><div class="submit-button"><input type="submit" value="Perform"></div></td></tr>
     </table>
 </form:form>


### PR DESCRIPTION
Backport of https://github.com/steve-community/steve/pull/1809 and https://github.com/steve-community/steve/pull/1816

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Remote Start Transaction: optionally select a Charging Profile when starting a transaction; form shows a Charging Profile dropdown and supported profiles include the profile in remote-start requests.
  - Set Charging Profile: added Transaction ID field for TxProfile flows; Connector ID input improved to numeric with clearer validation.

- Refactor
  - Centralized charging-profile mapping, validation and transaction-id handling to ensure consistent request construction and enforce TxProfile constraints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->